### PR TITLE
Additional delete run examples in mongo_queries.ipynb

### DIFF
--- a/mongo_queries.ipynb
+++ b/mongo_queries.ipynb
@@ -1083,8 +1083,11 @@
     "    \n",
     "    \n",
     "    # Delete all metrics\n",
-    "    for metric in ex['info']['metrics']:\n",
-    "        db.metrics.delete_one(dict(_id=metric['id']))\n",
+    "    try:\n",
+    "        for metric in ex['info']['metrics']:\n",
+    "            db.metrics.delete_one(dict(_id=metric['id']))\n",
+    "    except KeyError:\n",
+    "        print(\"KeyError: No metrics to delete..\")\n",
     "    \n",
     "    # Delete experiment\n",
     "    db.runs.delete_one(dict(_id=experiment_id))\n",
@@ -1349,7 +1352,42 @@
    "source": [
     "delete_experiments_by_query('val_acc<0.85 or fc_dim<=20 or status!=\"COMPLETED\"', db)\n",
     "df_summary = sacred_to_df(db.runs).query('val_acc>0.85 and fc_dim<=100').sort_values('val_acc', ascending=False)\n",
-    "display(df_summary)"
+    "display(df_summary)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def delete_experiments_by_dict(query, db):\n",
+    "    df_to_delete = sacred_to_df(db.runs, query)\n",
+    "    ids_to_delete = df_to_delete.index.tolist()\n",
+    "    for ex_id in ids_to_delete:\n",
+    "        delete_experiment(ex_id, db)\n",
+    "\n",
+    "# delete runs without an omniboard tag/note\n",
+    "ids_to_delete  = delete_experiments_by_dict({'omniboard': {'$exists': False}}, db)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# delete short sacred runs (e.g. shorter than 15minutes)\n",
+    "# subtract two time stamps using mongodb aggregate\n",
+    "# use heartbeat instead of stop_time in case the runs failed\n",
+    "def delete_short_sacred_runs(db):\n",
+    "    min_run_time_in_minutes = 15\n",
+    "    df = pd.DataFrame(list(db.runs.aggregate([{'$project': {\n",
+    "        \"dateDifference\": {'$lt': [{'$subtract': ['$heartbeat', '$start_time']}, 1000 * 60 * min_run_time_in_minutes]}}}])))\n",
+    "    df_time_dff = df.loc[df['dateDifference'] == True]\n",
+    "    ids_time_diff = df_time_dff['_id'].tolist()\n",
+    "    for ex_id in ids_time_diff:\n",
+    "        delete_experiment(ex_id, db)"
    ]
   },
   {


### PR DESCRIPTION
Added examples to delete only if no Omniboard tags or notes exist.
Delete if duration less than 15 minutes.
Try to delete metrics if they exist.